### PR TITLE
make compatible with kube-prom 63.x

### DIFF
--- a/manifests/kube-prometheus-stack.values
+++ b/manifests/kube-prometheus-stack.values
@@ -3567,7 +3567,7 @@ prometheus:
     ## prometheus resource to be created with selectors based on values in the helm deployment,
     ## which will also match the PrometheusRule resources created
     ##
-    ruleSelectorNilUsesHelmValues: true
+    # ruleSelectorNilUsesHelmValues: true
 
     ## PrometheusRules to be selected for target discovery.
     ## If {}, select all PrometheusRules
@@ -3592,7 +3592,7 @@ prometheus:
     ## prometheus resource to be created with selectors based on values in the helm deployment,
     ## which will also match the servicemonitors created
     ##
-    serviceMonitorSelectorNilUsesHelmValues: false 
+    # serviceMonitorSelectorNilUsesHelmValues: false 
 
     ## ServiceMonitors to be selected for target discovery.
     ## If {}, select all ServiceMonitors
@@ -3615,7 +3615,7 @@ prometheus:
     ## prometheus resource to be created with selectors based on values in the helm deployment,
     ## which will also match the podmonitors created
     ##
-    podMonitorSelectorNilUsesHelmValues: true
+    # podMonitorSelectorNilUsesHelmValues: true
 
     ## PodMonitors to be selected for target discovery.
     ## If {}, select all PodMonitors
@@ -3637,7 +3637,7 @@ prometheus:
     ## prometheus resource to be created with selectors based on values in the helm deployment,
     ## which will also match the probes created
     ##
-    probeSelectorNilUsesHelmValues: true
+    # probeSelectorNilUsesHelmValues: true
 
     ## Probes to be selected for target discovery.
     ## If {}, select all Probes
@@ -3659,7 +3659,7 @@ prometheus:
     ## prometheus resource to be created with selectors based on values in the helm deployment,
     ## which will also match the scrapeConfigs created
     ##
-    scrapeConfigSelectorNilUsesHelmValues: true
+    # scrapeConfigSelectorNilUsesHelmValues: true
 
     ## scrapeConfigs to be selected for target discovery.
     ## If {}, select all scrapeConfigs
@@ -4485,7 +4485,7 @@ thanosRuler:
     ## prometheus resource to be created with selectors based on values in the helm deployment,
     ## which will also match the PrometheusRule resources created
     ##
-    ruleSelectorNilUsesHelmValues: true
+    # ruleSelectorNilUsesHelmValues: true
 
     ## PrometheusRules to be selected for target discovery.
     ## If {}, select all PrometheusRules


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

bumps `kube-prom-stack.values` to 63.x

<!-- Describe the tests ran -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
```
helm upgrade --install kube-prometheus-stack prometheus-community/kube-prometheus-stack     --create-namespace     --namespace prometheus     --values kube-prometheus-stack.values     --wait
kubectl get pods
NAME                                                        READY   STATUS    RESTARTS   AGE
alertmanager-kube-prometheus-stack-alertmanager-0           2/2     Running   0          110s
kube-prometheus-stack-grafana-595776bcf8-xpgts              2/2     Running   0          117s
kube-prometheus-stack-kube-state-metrics-6c9cfcc698-58tzl   1/1     Running   0          117s
kube-prometheus-stack-operator-774d8bb5c4-dlw8d             1/1     Running   0          117s
kube-prometheus-stack-prometheus-node-exporter-7bwkm        1/1     Running   0          117s
kube-prometheus-stack-prometheus-node-exporter-7xsjr        1/1     Running   0          118s
kube-prometheus-stack-prometheus-node-exporter-8hpkf        1/1     Running   0          118s
kube-prometheus-stack-prometheus-node-exporter-c44dz        1/1     Running   0          117s
kube-prometheus-stack-prometheus-node-exporter-zcch8        1/1     Running   0          118s
prometheus-kube-prometheus-stack-prometheus-0               2/2     Running   0          110s
```